### PR TITLE
removed name property from top-level form

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,5 +34,5 @@
       "version": "detect"
     }
   },
-  "ignorePatterns": ["src-exists.cjs"]
+  "ignorePatterns": ["src-exists.cjs", "dist"]
 }

--- a/README.md
+++ b/README.md
@@ -50,12 +50,11 @@ First, we need to define the data model for our form. We do this by extending th
 
     class SignUpTemplate extends FormTemplate {}
 
-`FormTemplate` is an abstract class that provides certain useful defaults for properties that might not always be customized by developers, but at minimum, requires that a `name` and array of form elements be provided. Let's provide those now:
+`FormTemplate` is an abstract class that provides certain useful defaults for properties that might not always be customized by developers, but at minimum, requires that an array of form elements be provided. Let's extend the FormTemplate class:
 
     import { FormTemplate, Field, StringValidators } from 'fully-formed';
 
     class SignUpTemplate extends FormTemplate {
-      public readonly name = 'signUpForm';
       public readonly formElements = [
         new Field({
           name : 'email',
@@ -77,7 +76,6 @@ The particular validator we will be instantiating here returns an object contain
     import { FormTemplate, Field, StringValidators } from 'fully-formed';
 
     class SignUpTemplate extends FormTemplate {
-      public readonly name = 'signUpForm';
       public readonly formElements = [
         new Field({
           name : 'email',
@@ -107,7 +105,6 @@ Since this is a sign up form, let's add password and confirm password fields.
     import { FormTemplate, Field, StringValidators } from 'fully-formed';
 
     class SignUpTemplate extends FormTemplate {
-      public readonly name = 'signUpForm';
       public readonly formElements = [
         new Field({
           name : 'email',
@@ -174,7 +171,6 @@ Groups allow you to group together fields (or even other groups) in order to val
     } from 'fully-formed';
 
     class SignUpTemplate extends FormTemplate {
-      public readonly name = 'signUpForm';
       public readonly formElements = [
         new Field({
           name : 'email',
@@ -432,7 +428,6 @@ Here is an example in which we adapt a string-type field so that the value inclu
     } from 'fully-formed';
 
     class ExampleTemplate extends FormTemplate {
-      public readonly name = 'exampleForm';
       public readonly formElements = [
         new Field({
           name : 'age',
@@ -486,7 +481,6 @@ One field may control another. This is useful if certain information collected f
     import { zipToState } from './zip-to-state.ts';
 
     class AddressTemplate extends FormTemplate {
-      public readonly name = 'addressForm';
       public readonly formElements : [
         NonTransientField<'zip', string>,
         NonTransientField<'state', string>
@@ -543,7 +537,6 @@ Derived values allow you to produce values from your form constituents. You can 
     } from 'fully-formed';
 
     class ExampleTemplate extends FormTemplate {
-      public readonly name = 'exampleForm';
       public readonly formElements = [
         new Field({
           name : 'firstName',
@@ -577,7 +570,6 @@ The `FFCheckbox` component accepts a field whose value is of type boolean. When 
     } from "fully-formed";
 
     class CheckboxExampleTemplate extends FormTemplate {
-      public readonly name = "checkboxExample";
       public readonly formElements = [
         new Field({
           name: "acceptTerms",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fully-formed",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Powerful, type-safe, style-agnostic forms for React.",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/__test__/components/controls/ff-checkbox.test.tsx
+++ b/src/__test__/components/controls/ff-checkbox.test.tsx
@@ -11,7 +11,6 @@ describe('FFCheckbox', () => {
 
   test('It renders an input component and a label inside a div.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -54,7 +53,6 @@ describe('FFCheckbox', () => {
   test(`It renders an input element whose name matches that of the field it 
   received.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -86,7 +84,6 @@ describe('FFCheckbox', () => {
   test(`It renders an input element whose id matches that of the field it 
   received.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -119,7 +116,6 @@ describe('FFCheckbox', () => {
   test(`It renders a label whose htmlFor attribute matches the id of the field 
   it received.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -152,7 +148,6 @@ describe('FFCheckbox', () => {
   test(`It renders the content it receives through the labelContent prop inside 
   the label it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -187,7 +182,6 @@ describe('FFCheckbox', () => {
   test(`The checked attribute of the input it renders defaults to the value of 
   the field it received.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'trueByDefault',
@@ -231,7 +225,6 @@ describe('FFCheckbox', () => {
   test(`When the value of the underlying field is updated, the checked attribute 
   of the input it renders is updated.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -265,7 +258,6 @@ describe('FFCheckbox', () => {
   test(`When the user clicks the checkbox, the checked attribute of the input it 
   renders changes.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -304,7 +296,6 @@ describe('FFCheckbox', () => {
   test(`When the user clicks the checkbox, the value of the underlying field is 
   updated.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -342,7 +333,6 @@ describe('FFCheckbox', () => {
   test(`When the user clicks on the input, the focused property of the state of 
   the underlying field becomes true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -377,7 +367,6 @@ describe('FFCheckbox', () => {
   test(`When the input receives focus and is then blurred, the visited property 
   of the state of the underlying field becomes true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -415,7 +404,6 @@ describe('FFCheckbox', () => {
   test(`If it received containerClassName in its props, that className is 
   applied to the div it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -449,7 +437,6 @@ describe('FFCheckbox', () => {
   test(`If it received getContainerClassName() is its props, that function is 
   called, and the div it renders receives the resultant className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -484,7 +471,6 @@ describe('FFCheckbox', () => {
   getContainerClassName() is called, the resultant className is joined with 
   containerClassName, and the result is applied to the div it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -519,7 +505,6 @@ describe('FFCheckbox', () => {
   test(`If it received containerStyle, those styles are applied to the div 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -559,7 +544,6 @@ describe('FFCheckbox', () => {
   test(`If it received getContainerStyle(), that function is called and the
   resultant styles are applied to the div element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -600,7 +584,6 @@ describe('FFCheckbox', () => {
   getContainerStyle() is called, and the result is merged with containerStyle
   and then applied to the div element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -642,7 +625,6 @@ describe('FFCheckbox', () => {
   test(`If it received checkboxClassName in its props, that className is 
   applied to the input it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -675,7 +657,6 @@ describe('FFCheckbox', () => {
   test(`If it received getCheckboxClassName() is its props, that function is 
   called, and the input it renders receives the resultant className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -709,7 +690,6 @@ describe('FFCheckbox', () => {
   getCheckboxClassName() is called, the resultant className is joined with 
   checkboxClassName, and the result is applied to the input it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -743,7 +723,6 @@ describe('FFCheckbox', () => {
   test(`If it received checkboxStyle, those styles are applied to the input 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -780,7 +759,6 @@ describe('FFCheckbox', () => {
   test(`If it received getCheckboxStyle(), that function is called and the
   resultant styles are applied to the input element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -818,7 +796,6 @@ describe('FFCheckbox', () => {
   getCheckboxStyle() is called, and the result is merged with checkboxStyle
   and then applied to the input element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -857,7 +834,6 @@ describe('FFCheckbox', () => {
   test(`If it received labelClassName in its props, that className is 
   applied to the label it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -890,7 +866,6 @@ describe('FFCheckbox', () => {
   test(`If it received getLabelClassName() is its props, that function is 
   called, and the label it renders receives the resultant className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -924,7 +899,6 @@ describe('FFCheckbox', () => {
   getLabelClassName() is called, the resultant className is joined with 
   labelClassName, and the result is applied to the label it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -958,7 +932,6 @@ describe('FFCheckbox', () => {
   test(`If it received labelStyle, those styles are applied to the label 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -995,7 +968,6 @@ describe('FFCheckbox', () => {
   test(`If it received getLabelStyle(), that function is called and the
   resultant styles are applied to the label element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',
@@ -1033,7 +1005,6 @@ describe('FFCheckbox', () => {
   getLabelStyle() is called, and the result is merged with labelStyle
   and then applied to the label element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testCheckbox',

--- a/src/__test__/components/controls/ff-input.test.tsx
+++ b/src/__test__/components/controls/ff-input.test.tsx
@@ -20,7 +20,6 @@ describe('FFInput', () => {
 
   test('It renders an input element.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -44,7 +43,6 @@ describe('FFInput', () => {
   test(`It renders an input element whose name matches that of the field it 
   receives as a prop.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -69,7 +67,6 @@ describe('FFInput', () => {
   test(`It renders an input element whose id matches that of the field it 
   receives as a prop.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField1', defaultValue: '' }),
         new Field({ name: 'testField2', defaultValue: '', id: 'test-field-2' }),
@@ -106,7 +103,6 @@ describe('FFInput', () => {
 
   test('It renders an input element of the type specified by its type prop.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -157,7 +153,6 @@ describe('FFInput', () => {
   test(`It renders an input element whose value is initialized to the default 
   value of the field it received as a prop.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'name', defaultValue: 'Joan Tower' }),
       ] as const;
@@ -180,7 +175,6 @@ describe('FFInput', () => {
   test(`Its value is updated when text is entered into the input element it 
   renders.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'name', defaultValue: '' }),
       ] as const;
@@ -216,7 +210,6 @@ describe('FFInput', () => {
     };
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements: [
         AbstractField<'brandPrimary', string, false>,
         AbstractField<'brandSecondary', string, false>,
@@ -291,7 +284,6 @@ describe('FFInput', () => {
   test(`When its value is updated, the modified property of the state of the 
   underlying field becomes true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'name', defaultValue: '' }),
       ] as const;
@@ -316,7 +308,6 @@ describe('FFInput', () => {
   test(`When it receives focus, the focused property of the state of the 
   underlying field becomes true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -343,7 +334,6 @@ describe('FFInput', () => {
   test(`When it is blurred, the visited property of the state of the underlying 
   field becomes true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -372,7 +362,6 @@ describe('FFInput', () => {
 
   test('If its props include className, the input it renders receives that className.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -402,7 +391,6 @@ describe('FFInput', () => {
   test(`If its props include getClassName that function is called the input 
   element it renders receives the resulting className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -432,7 +420,6 @@ describe('FFInput', () => {
   test(`If its props include both className and getClassName, getClassName() is 
   called and then merged with className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -463,7 +450,6 @@ describe('FFInput', () => {
   test(`If its props include style, those styles are applied to the input 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -501,7 +487,6 @@ describe('FFInput', () => {
   test(`If its props include getStyle(), getStyle() is called and the result is 
   applied to the style of the input element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -542,7 +527,6 @@ describe('FFInput', () => {
   the result is merged with the style prop and applied to the style of the input 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -583,7 +567,6 @@ describe('FFInput', () => {
 
   test('If props.disabled is true, the input element it renders is disabled.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -613,7 +596,6 @@ describe('FFInput', () => {
   test(`If props.disableWhenExcluded is true, the input element it renders is 
   disabled when the underlying field is excluded.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new ExcludableField({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -645,7 +627,6 @@ describe('FFInput', () => {
   test(`If props.disabled and props.disabledWhenExcluded are both true, but the 
   field is not currently excluded, it is still disabled.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new ExcludableField({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -676,7 +657,6 @@ describe('FFInput', () => {
   test(`If the field has not been modified or visited and the confirm() method 
   of the form has not been called, its aria-invalid property is false.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -704,7 +684,6 @@ describe('FFInput', () => {
   test(`If the field has been modified and the underlying field is invalid, its 
   aria-invalid property is true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -737,7 +716,6 @@ describe('FFInput', () => {
   test(`If the field has been visited and the underlying field is invalid, its 
   aria-invalid property is true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -770,7 +748,6 @@ describe('FFInput', () => {
   test(`If the confirm() method of the form has been called and the underlying 
   field is invalid, its aria-invalid property is true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',

--- a/src/__test__/components/controls/ff-multi-select.test.tsx
+++ b/src/__test__/components/controls/ff-multi-select.test.tsx
@@ -12,7 +12,6 @@ describe('FFMultiSelect', () => {
 
   test('It renders an html select element.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -46,7 +45,6 @@ describe('FFMultiSelect', () => {
   test(`The name property of the select element it renders is set to the name 
   property of the underlying field.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -79,7 +77,6 @@ describe('FFMultiSelect', () => {
   test(`The id property of the select element it renders is set to the id 
   property of the underlying field.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -113,7 +110,6 @@ describe('FFMultiSelect', () => {
   test(`Any options or optgroups it receives are rendered inside the select 
   element.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteInstruments', string[], false>({
           name: 'favoriteInstruments',
@@ -197,7 +193,6 @@ describe('FFMultiSelect', () => {
   test(`The value of the select element is the first option that is included 
   in the value of the underlying field.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -231,7 +226,6 @@ describe('FFMultiSelect', () => {
   test(`The values of the selectedOptions of the select element are the values 
   included in the value array of the underlying field.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -270,7 +264,6 @@ describe('FFMultiSelect', () => {
   test(`When the value of the underlying field is updated, the value of the
   select element is updated.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -306,7 +299,6 @@ describe('FFMultiSelect', () => {
   test(`When the value of the underlying field is updated, the selectedOptions
   property of the select element is updated.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -348,7 +340,6 @@ describe('FFMultiSelect', () => {
   test(`When the user selects an option, the value of the underlying field is 
   updated.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -388,7 +379,6 @@ describe('FFMultiSelect', () => {
   test(`When the user deselects an option, the value of the underlying field is
   updated.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -439,7 +429,6 @@ describe('FFMultiSelect', () => {
   test(`When the select element receives focus, the focused property of the 
   state of the underlying field becomes true.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -474,7 +463,6 @@ describe('FFMultiSelect', () => {
   test(`When the select element receives focus and is then blurred, the 
   visited property of the underlying field becomes true.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -512,7 +500,6 @@ describe('FFMultiSelect', () => {
   test(`If its props include className, the select element it renders receives 
   that className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -550,7 +537,6 @@ describe('FFMultiSelect', () => {
   test(`If its props include getClassName, that function is called the select 
   element it renders receives the resulting className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -588,7 +574,6 @@ describe('FFMultiSelect', () => {
   test(`If its props include both className and getClassName, getClassName() is 
   called and then merged with className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -627,7 +612,6 @@ describe('FFMultiSelect', () => {
   test(`If its props include style, those styles are applied to the select 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -673,7 +657,6 @@ describe('FFMultiSelect', () => {
   test(`If its props include getStyle(), getStyle() is called and the result is 
   applied to the select element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',
@@ -720,7 +703,6 @@ describe('FFMultiSelect', () => {
   the result is merged with the style prop and applied to the select element it 
   renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field<'favoriteFruits', string[], false>({
           name: 'favoriteFruits',

--- a/src/__test__/components/controls/ff-radio-group.test.tsx
+++ b/src/__test__/components/controls/ff-radio-group.test.tsx
@@ -23,7 +23,6 @@ describe('FFRadioGroup', () => {
 
   test('It renders a fieldset element.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -48,7 +47,6 @@ describe('FFRadioGroup', () => {
 
   test('It renders child components inside the fieldset element.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field<'favoriteColor', 'red' | 'green' | 'blue', false>({
           name: 'favoriteColor',
@@ -106,7 +104,6 @@ describe('FFRadioGroup', () => {
   test(`It calls getLegendId() with the id of the field it receives and sets the 
   aria-labelledby attribute of the fieldset to the result.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -135,7 +132,6 @@ describe('FFRadioGroup', () => {
   receives and set the aria-describedby attribute of the fieldset to the 
   result.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -165,7 +161,6 @@ describe('FFRadioGroup', () => {
   field, and the aria-describedby property of the fieldset is set to the 
   result.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -203,7 +198,6 @@ describe('FFRadioGroup', () => {
   underlying field is clean and the confirm() method of the form has not been 
   called, even if the validity of the field is invalid.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -230,7 +224,6 @@ describe('FFRadioGroup', () => {
   test(`The aria-invalid attribute of the fieldset is true if the underlying 
   field is invalid and the field has been visited.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -259,7 +252,6 @@ describe('FFRadioGroup', () => {
   test(`The aria-invalid attribute of the fieldset is true if the underlying 
   field is invalid and the field has been modified.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -289,7 +281,6 @@ describe('FFRadioGroup', () => {
   field is invalid and the confirm() method of the parent form has been 
   called.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -318,7 +309,6 @@ describe('FFRadioGroup', () => {
   test(`If any groups are passed into the component, their validity impacts the 
   aria-invalid attribute of the fieldset.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'fieldOne',
@@ -368,12 +358,9 @@ describe('FFRadioGroup', () => {
     expect(fieldset.ariaInvalid).toBe('true');
   });
 
-  //////
-
   test(`If its props include className, the fieldset it renders receives that 
   className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -402,7 +389,6 @@ describe('FFRadioGroup', () => {
   test(`If its props include getClassName(), that function is called and the 
   fieldset element it renders receives the resulting className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -431,7 +417,6 @@ describe('FFRadioGroup', () => {
   test(`If its props include both className and getClassName, getClassName() is 
   called and then merged with className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -461,7 +446,6 @@ describe('FFRadioGroup', () => {
   test(`If its props include style, those styles are applied to the fieldset 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -498,7 +482,6 @@ describe('FFRadioGroup', () => {
   test(`If its props include getStyle(), getStyle() is called and the fieldset 
   receives the resultant styles.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -536,7 +519,6 @@ describe('FFRadioGroup', () => {
   the result is merged with the style prop and applied to the style of the 
   fieldset`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;

--- a/src/__test__/components/controls/ff-radio.test.tsx
+++ b/src/__test__/components/controls/ff-radio.test.tsx
@@ -11,7 +11,6 @@ describe('FFRadio', () => {
 
   test(`It renders a radio button and a label inside a div.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -55,7 +54,6 @@ describe('FFRadio', () => {
   test(`The name property of the field it receives is assigned to the name 
   attribute of the input element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -88,7 +86,6 @@ describe('FFRadio', () => {
   test(`The value prop it receives is assigned to the value attribute of the 
   input element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field<'favoriteColor', 'red' | 'green' | 'blue', false>({
           name: 'favoriteColor',
@@ -137,7 +134,6 @@ describe('FFRadio', () => {
   test(`The htmlFor attribute of the label it renders matches the id attribute 
   of the input element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -172,7 +168,6 @@ describe('FFRadio', () => {
   test(`It renders the content it receives in the labelContent prop inside the 
   label element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -208,7 +203,6 @@ describe('FFRadio', () => {
   test(`The input it renders is checked when the value of the field matches that 
   of the input.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field<'favoriteColor', 'red' | 'green' | 'blue', false>({
           name: 'favoriteColor',
@@ -269,7 +263,6 @@ describe('FFRadio', () => {
   test(`When the user clicks on the radio input, it updates the value of the
   underlying field.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -305,7 +298,6 @@ describe('FFRadio', () => {
   test(`The input it renders is checked when the value of the field matches that 
   of the input.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field<'favoriteColor', '' | 'red' | 'green' | 'blue', false>({
           name: 'favoriteColor',
@@ -363,7 +355,6 @@ describe('FFRadio', () => {
   test(`When the user presses the spacebar on an unchecked radio button, it
   becomes checked.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field<'favoriteColor', '' | 'red' | 'green' | 'blue', false>({
           name: 'favoriteColor',
@@ -413,7 +404,6 @@ describe('FFRadio', () => {
   test(`When the radio button it renders receives focus, the focused property of
   the state of the underlying field is set to true.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -449,7 +439,6 @@ describe('FFRadio', () => {
   the visited property of the state of the underlying field becomes 
   true.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'myFormTemplate';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -485,7 +474,6 @@ describe('FFRadio', () => {
   test(`If it received containerClassName in its props, that className is 
   applied to the div it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -520,7 +508,6 @@ describe('FFRadio', () => {
   test(`If it received getContainerClassName() is its props, that function is 
   called, and the div it renders receives the resultant className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -556,7 +543,6 @@ describe('FFRadio', () => {
   getContainerClassName() is called, the resultant className is joined with 
   containerClassName, and the result is applied to the div it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -592,7 +578,6 @@ describe('FFRadio', () => {
   test(`If it received containerStyle, those styles are applied to the div 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -633,7 +618,6 @@ describe('FFRadio', () => {
   test(`If it received getContainerStyle(), that function is called and the
   resultant styles are applied to the div element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -675,7 +659,6 @@ describe('FFRadio', () => {
   getContainerStyle() is called, and the result is merged with containerStyle
   and then applied to the div element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -718,7 +701,6 @@ describe('FFRadio', () => {
   test(`If it received radioClassName in its props, that className is 
   applied to the input it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -752,7 +734,6 @@ describe('FFRadio', () => {
   test(`If it received getRadioClassName() is its props, that function is 
   called, and the input it renders receives the resultant className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -787,7 +768,6 @@ describe('FFRadio', () => {
   getRadioClassName() is called, the resultant className is joined with 
   radioClassName, and the result is applied to the input it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -822,7 +802,6 @@ describe('FFRadio', () => {
   test(`If it received radioStyle, those styles are applied to the input 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -860,7 +839,6 @@ describe('FFRadio', () => {
   test(`If it received getRadioStyle(), that function is called and the
   resultant styles are applied to the input element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -899,7 +877,6 @@ describe('FFRadio', () => {
   getRadioStyle() is called, and the result is merged with radioStyle
   and then applied to the input element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -939,7 +916,6 @@ describe('FFRadio', () => {
   test(`If it received labelClassName in its props, that className is 
   applied to the label it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -973,7 +949,6 @@ describe('FFRadio', () => {
   test(`If it received getLabelClassName() is its props, that function is 
   called, and the label it renders receives the resultant className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -1008,7 +983,6 @@ describe('FFRadio', () => {
   getLabelClassName() is called, the resultant className is joined with 
   labelClassName, and the result is applied to the label it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -1043,7 +1017,6 @@ describe('FFRadio', () => {
   test(`If it received labelStyle, those styles are applied to the label 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -1081,7 +1054,6 @@ describe('FFRadio', () => {
   test(`If it received getLabelStyle(), that function is called and the
   resultant styles are applied to the label element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -1120,7 +1092,6 @@ describe('FFRadio', () => {
   getLabelStyle() is called, and the result is merged with labelStyle
   and then applied to the label element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',

--- a/src/__test__/components/controls/ff-select.test.tsx
+++ b/src/__test__/components/controls/ff-select.test.tsx
@@ -11,7 +11,6 @@ describe('FFSelect', () => {
 
   test('It renders an html select element.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -45,7 +44,6 @@ describe('FFSelect', () => {
   test(`The name property of the select element it renders is set to the name 
   property of the underlying field.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -78,7 +76,6 @@ describe('FFSelect', () => {
   test(`The id property of the select element it renders is set to the id 
   property of the underlying field.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -112,7 +109,6 @@ describe('FFSelect', () => {
   test(`Any options or optgroups it receives are rendered inside the select 
   element.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteInstrument',
@@ -193,7 +189,6 @@ describe('FFSelect', () => {
   test(`The value of the select element is set to the value of the underlying 
   field.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -227,7 +222,6 @@ describe('FFSelect', () => {
   test(`When the value of the underlying field is updated, the value of the
   select element is updated.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -263,7 +257,6 @@ describe('FFSelect', () => {
   test(`When the user selects an option, the value of the underlying field is 
   updated.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -299,7 +292,6 @@ describe('FFSelect', () => {
   test(`When the select element receives focus, the focused property of the 
   state of the underlying field becomes true.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -334,7 +326,6 @@ describe('FFSelect', () => {
   test(`When the select element receives focus and is then blurred, the 
   visited property of the underlying field becomes true.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -372,7 +363,6 @@ describe('FFSelect', () => {
   test(`If its props include className, the select element it renders receives 
   that className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -410,7 +400,6 @@ describe('FFSelect', () => {
   test(`If its props include getClassName, that function is called the select 
   element it renders receives the resulting className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -448,7 +437,6 @@ describe('FFSelect', () => {
   test(`If its props include both className and getClassName, getClassName() is 
   called and then merged with className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -487,7 +475,6 @@ describe('FFSelect', () => {
   test(`If its props include style, those styles are applied to the select 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -533,7 +520,6 @@ describe('FFSelect', () => {
   test(`If its props include getStyle(), getStyle() is called and the result is 
   applied to the select element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',
@@ -580,7 +566,6 @@ describe('FFSelect', () => {
   the result is merged with the style prop and applied to the select element it 
   renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'favoriteFruit',

--- a/src/__test__/components/controls/ff-textarea.test.tsx
+++ b/src/__test__/components/controls/ff-textarea.test.tsx
@@ -11,7 +11,6 @@ describe('FFTextArea', () => {
 
   test('It renders a textarea element.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -33,7 +32,6 @@ describe('FFTextArea', () => {
   test(`It renders a textarea element whose name matches that of the field it 
   receives as a prop.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -56,7 +54,6 @@ describe('FFTextArea', () => {
   test(`It renders a textarea element whose id matches that of the field it 
   receives as a prop.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'testField',
@@ -83,7 +80,6 @@ describe('FFTextArea', () => {
   test(`It renders a textarea element whose value is initialized to the default 
   value of the field it received as a prop.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'comments', defaultValue: 'Lorem ipsum dolor est' }),
       ] as const;
@@ -106,7 +102,6 @@ describe('FFTextArea', () => {
   test(`Its value is updated when text is entered into the textarea element it 
   renders.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'comments', defaultValue: '' }),
       ] as const;
@@ -133,7 +128,6 @@ describe('FFTextArea', () => {
   test(`When its value is updated, the modified property of the state of the 
   underlying field becomes true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'comments', defaultValue: '' }),
       ] as const;
@@ -158,7 +152,6 @@ describe('FFTextArea', () => {
   test(`When it receives focus, the focused property of the state of the 
   underlying field becomes true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -183,7 +176,6 @@ describe('FFTextArea', () => {
   test(`When it is blurred, the visited property of the state of the underlying 
   field becomes true.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -211,7 +203,6 @@ describe('FFTextArea', () => {
   test(`If its props include className, the textarea it renders receives that 
   className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -240,7 +231,6 @@ describe('FFTextArea', () => {
   test(`If its props include getClassName that function is called the textarea 
   element it renders receives the resulting className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -269,7 +259,6 @@ describe('FFTextArea', () => {
   test(`If its props include both className and getClassName, getClassName() is 
   called and then merged with className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -299,7 +288,6 @@ describe('FFTextArea', () => {
   test(`If its props include style, those styles are applied to the textarea 
   element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -336,7 +324,6 @@ describe('FFTextArea', () => {
   test(`If its props include getStyle(), getStyle() is called and the result is 
   applied to the style of the textarea element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -374,7 +361,6 @@ describe('FFTextArea', () => {
   the result is merged with the style prop and applied to the style of the  
   textarea element it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;

--- a/src/__test__/components/labels/ff-label.test.tsx
+++ b/src/__test__/components/labels/ff-label.test.tsx
@@ -11,7 +11,6 @@ describe('FFLabel', () => {
 
   test('It renders a label element.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -33,7 +32,6 @@ describe('FFLabel', () => {
   test(`The id of the field it receives as a prop is assigned to the htmlFor
     attribute of the label it renders.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '', id: 'test-field' }),
       ] as const;
@@ -55,7 +53,6 @@ describe('FFLabel', () => {
 
   test('It renders child components inside the label.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -93,7 +90,6 @@ describe('FFLabel', () => {
   test(`If it received a className as a prop, the label it returns receives that 
   className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -122,7 +118,6 @@ describe('FFLabel', () => {
   test(`If it received getClassName() as a prop, getClassName() is called and 
   the label it returns receives the resulting className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -152,7 +147,6 @@ describe('FFLabel', () => {
   getClassName() is called and merged with className, and the label it returns 
   receives the resulting className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -182,7 +176,6 @@ describe('FFLabel', () => {
   test(`If it received style as a prop, those styles are applied to the label 
   element it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -217,7 +210,6 @@ describe('FFLabel', () => {
   test(`If it received getStyle() as a prop, that function is called and the
   resultant styles are applied to the label element it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -253,7 +245,6 @@ describe('FFLabel', () => {
   called and the resultant styles are merged with style and applied to the label 
   element it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;

--- a/src/__test__/components/labels/ff-radio-group-legend.test.tsx
+++ b/src/__test__/components/labels/ff-radio-group-legend.test.tsx
@@ -11,7 +11,6 @@ describe('FFRadioGroupLegend', () => {
 
   test('It renders a legend element.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -35,7 +34,6 @@ describe('FFRadioGroupLegend', () => {
   test(`getLegendId() is called with the id of the field it receives and 
   assigned to its id property.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '', id: 'test-field' }),
       ] as const;
@@ -59,7 +57,6 @@ describe('FFRadioGroupLegend', () => {
 
   test('It renders child components inside the legend.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -97,7 +94,6 @@ describe('FFRadioGroupLegend', () => {
   test(`If it received a className as a prop, the legend it returns receives 
   that className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -126,7 +122,6 @@ describe('FFRadioGroupLegend', () => {
   test(`If it received getClassName() as a prop, getClassName() is called and 
   the legend it returns receives the resulting className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -156,7 +151,6 @@ describe('FFRadioGroupLegend', () => {
   getClassName() is called and merged with className, and the legend it returns 
   receives the resulting className.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -186,7 +180,6 @@ describe('FFRadioGroupLegend', () => {
   test(`If it received style as a prop, those styles are applied to the legend 
   element it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -221,7 +214,6 @@ describe('FFRadioGroupLegend', () => {
   test(`If it received getStyle() as a prop, that function is called and the
   resultant styles are applied to the legend element it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -257,7 +249,6 @@ describe('FFRadioGroupLegend', () => {
   called and the resultant styles are merged with style and applied to the 
   legend element it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;

--- a/src/__test__/components/messages/ff-field-messages.test.tsx
+++ b/src/__test__/components/messages/ff-field-messages.test.tsx
@@ -23,7 +23,6 @@ describe('FFFieldMessages', () => {
   test(`It renders a div element with an id derived from the id of the field it 
   received as a prop.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -50,7 +49,6 @@ describe('FFFieldMessages', () => {
   test(`If its props contain containerClassName, that className is applied to 
   the div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -80,7 +78,6 @@ describe('FFFieldMessages', () => {
   test(`If its props contain getContainerClassName(), that function is called
   and the resultant className is applied to the the div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -112,7 +109,6 @@ describe('FFFieldMessages', () => {
   returns is merged with containerClassName, and the result is applied to the 
   div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -143,7 +139,6 @@ describe('FFFieldMessages', () => {
   test(`If its props contain containerStyle, those styles are applied to the 
   div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -177,7 +172,6 @@ describe('FFFieldMessages', () => {
   test(`If its props contain getContainerStyle(), that function is called and 
   the resultant styles are applied to the div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -212,7 +206,6 @@ describe('FFFieldMessages', () => {
   getContainerStyle() is called and the resultant styles are merged with 
   containerStyle and applied to the div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({ name: 'testField', defaultValue: '' }),
       ] as const;
@@ -258,7 +251,6 @@ describe('FFFieldMessages', () => {
     };
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'password',
@@ -304,7 +296,6 @@ describe('FFFieldMessages', () => {
     const invalidMessage = 'The email address is valid.';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -349,8 +340,6 @@ describe('FFFieldMessages', () => {
       'Please ensure the re-entered password matches the password.';
 
     class Template extends FormTemplate {
-      public readonly name = 'signUpForm';
-
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -423,8 +412,6 @@ describe('FFFieldMessages', () => {
     const passwordsMatch = 'The passwords match.';
 
     class Template extends FormTemplate {
-      public readonly name = 'signUpForm';
-
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -510,7 +497,6 @@ describe('FFFieldMessages', () => {
     const messageText = 'Name is required';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'name',
@@ -549,7 +535,6 @@ describe('FFFieldMessages', () => {
     const messageText = 'Name is required';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'name',
@@ -590,7 +575,6 @@ describe('FFFieldMessages', () => {
     const messageText = 'Name is required';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'name',
@@ -630,7 +614,6 @@ describe('FFFieldMessages', () => {
     const messageText = 'Name is required';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'name',
@@ -681,7 +664,6 @@ describe('FFFieldMessages', () => {
       'The password must include an uppercase letter.';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'password',
@@ -732,7 +714,6 @@ describe('FFFieldMessages', () => {
       'The password must include an uppercase letter.';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'password',

--- a/src/__test__/components/messages/ff-group-messages.test.tsx
+++ b/src/__test__/components/messages/ff-group-messages.test.tsx
@@ -17,7 +17,6 @@ describe('FFGroupMessages', () => {
   test(`It renders a div element whose id is the containerId it received as a 
   prop.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -72,7 +71,6 @@ describe('FFGroupMessages', () => {
     };
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -163,7 +161,6 @@ describe('FFGroupMessages', () => {
   test(`If its props contain containerClassName, that className is applied to 
   the div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -207,7 +204,6 @@ describe('FFGroupMessages', () => {
   test(`If its props contain getContainerClassName(), that function is called
   and the resultant className is applied to the the div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -253,7 +249,6 @@ describe('FFGroupMessages', () => {
   returns is merged with containerClassName, and the result is applied to the 
   div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -298,7 +293,6 @@ describe('FFGroupMessages', () => {
   test(`If its props contain containerStyle, those styles are applied to the 
   div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -346,7 +340,6 @@ describe('FFGroupMessages', () => {
   test(`If its props contain getContainerStyle(), that function is called and 
   the resultant styles are applied to the div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -395,7 +388,6 @@ describe('FFGroupMessages', () => {
   getContainerStyle() is called and the resultant styles are merged with 
   containerStyle and applied to the div it returns.`, () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -446,14 +438,11 @@ describe('FFGroupMessages', () => {
     expect(container?.style.rowGap).toBe('8px');
   });
 
-  //////////////////////////////
-
   test(`If its props contain messageClassName, that className is applied to any 
   Message components it renders.`, () => {
     const messageText = 'Please ensure that the email addresses match.';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -505,7 +494,6 @@ describe('FFGroupMessages', () => {
     const messageText = 'Please ensure that the email addresses match.';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -559,7 +547,6 @@ describe('FFGroupMessages', () => {
     const messageText = 'Please ensure that the email addresses match.';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -612,7 +599,6 @@ describe('FFGroupMessages', () => {
     const messageText = 'Please ensure that the email addresses match.';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -674,7 +660,6 @@ describe('FFGroupMessages', () => {
     const messageText = 'Please ensure that the email addresses match.';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',
@@ -738,7 +723,6 @@ describe('FFGroupMessages', () => {
     const messageText = 'Please ensure that the email addresses match.';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',

--- a/src/__test__/hooks/use-combined-messages.test.tsx
+++ b/src/__test__/hooks/use-combined-messages.test.tsx
@@ -12,7 +12,6 @@ describe('useCombinedMessages()', () => {
   test(`It returns an array containing the messages of all messageBearers it 
   receives.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'stateAndZip';
       public readonly formElements = [
         new Field({
           name: 'state',

--- a/src/__test__/hooks/use-confirmation-attempted.test.tsx
+++ b/src/__test__/hooks/use-confirmation-attempted.test.tsx
@@ -10,7 +10,6 @@ describe('useConfirmationAttempted()', () => {
   test(`It returns a boolean value that indicates whether or not the confirm() 
   method of the form it receives has been called.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [];
     }
 

--- a/src/__test__/hooks/use-derived-value.test.tsx
+++ b/src/__test__/hooks/use-derived-value.test.tsx
@@ -18,8 +18,6 @@ describe('useDerivedValue()', () => {
     };
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
-
       public readonly formElements = [
         new Field({ name: 'birthday', defaultValue: '' }),
       ] as const;

--- a/src/__test__/hooks/use-exclude.test.tsx
+++ b/src/__test__/hooks/use-exclude.test.tsx
@@ -20,7 +20,6 @@ describe('useExclude()', () => {
   test(`It returns a boolean value indicating whether or not an Excludable 
   form element is excluded.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements: [
         AbstractField<'changedName', boolean, false>,
         AbstractExcludableField<'previousName', string, false>,

--- a/src/__test__/hooks/use-field-state.test.tsx
+++ b/src/__test__/hooks/use-field-state.test.tsx
@@ -18,7 +18,6 @@ describe('useFieldState()', () => {
     const validMessage = 'Email is valid.';
 
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'email',

--- a/src/__test__/hooks/use-form-state.test.tsx
+++ b/src/__test__/hooks/use-form-state.test.tsx
@@ -19,7 +19,6 @@ describe('useFormState()', () => {
   test(`It returns the state of a form, which is updated when the state of the
   form changes.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'firstName',

--- a/src/__test__/hooks/use-form.test.tsx
+++ b/src/__test__/hooks/use-form.test.tsx
@@ -10,7 +10,6 @@ describe('useForm()', () => {
   afterEach(cleanup);
 
   class Template extends FormTemplate {
-    public readonly name = 'testForm';
     public readonly formElements = [];
   }
 

--- a/src/__test__/hooks/use-group-state.test.tsx
+++ b/src/__test__/hooks/use-group-state.test.tsx
@@ -12,7 +12,6 @@ describe('useGroupState()', () => {
   test(`It returns the state of a group, which is updated when the state of the
   group changes.`, async () => {
     class Template extends FormTemplate {
-      public readonly name = 'testForm';
       public readonly formElements = [
         new Field({
           name: 'password',

--- a/src/__test__/model/form-elements/classes/abstract/excludable-subform.test.ts
+++ b/src/__test__/model/form-elements/classes/abstract/excludable-subform.test.ts
@@ -16,11 +16,14 @@ import {
   type ExcludableTemplate,
 } from '../../../../../model';
 import { PromiseScheduler } from '../../../../../test-utils';
-import { FormTemplate, type ControllableTemplate } from '../../../../../model';
+import {
+  SubFormTemplate,
+  type ControllableTemplate,
+} from '../../../../../model';
 
 describe('Form', () => {
   test('Its id defaults to its name.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = [];
     }
@@ -31,7 +34,7 @@ describe('Form', () => {
   });
 
   test('Its value consists of all included, non-transient fields.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'firstName', defaultValue: 'Georg' }),
@@ -49,7 +52,7 @@ describe('Form', () => {
   });
 
   test('Its value does not include any transient fields.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'password', defaultValue: '' }),
@@ -68,7 +71,7 @@ describe('Form', () => {
   });
 
   test('Its value does not include the values of any excluded excludable fields.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'primaryEmail', defaultValue: 'user@example.com' }),
@@ -87,7 +90,7 @@ describe('Form', () => {
   });
 
   test('Its value includes the values of any included user-defined adapters.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'birthYear', defaultValue: '1990', transient: true }),
@@ -110,7 +113,7 @@ describe('Form', () => {
   });
 
   test('Its value does not include the values of any excluded excludable adapters.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'firstName', defaultValue: '' }),
@@ -147,7 +150,7 @@ describe('Form', () => {
   });
 
   test('If any included fields are invalid, its validity is invalid.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -163,7 +166,7 @@ describe('Form', () => {
   });
 
   test('If any groups are invalid, its validity is invalid.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'password', defaultValue: 'password' }),
@@ -199,7 +202,7 @@ describe('Form', () => {
         return promiseScheduler.createScheduledPromise(value.length > 0);
       },
     });
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -216,7 +219,7 @@ describe('Form', () => {
 
   test('If there is at least one pending group and no invalid fields or groups, its validity is pending.', () => {
     const promiseScheduler = new PromiseScheduler();
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'AddressForm';
       public formElements = <const>[
         new Field({ name: 'streetAddress', defaultValue: '1726 Locust St.' }),
@@ -259,7 +262,7 @@ describe('Form', () => {
   });
 
   test('If all fields and groups are valid, its validity is valid.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -293,7 +296,7 @@ describe('Form', () => {
   });
 
   test('Its exclude property defaults to excludeByDefault.', () => {
-    class Template extends FormTemplate implements ExcludableTemplate {
+    class Template extends SubFormTemplate implements ExcludableTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = [];
       public readonly excludeByDefault = true;
@@ -307,7 +310,7 @@ describe('Form', () => {
     class Template<
         ControllingField extends AbstractField<string, boolean, boolean>,
       >
-      extends FormTemplate
+      extends SubFormTemplate
       implements ControllableTemplate<ControllingField>
     {
       public readonly name = 'TestForm';
@@ -332,7 +335,7 @@ describe('Form', () => {
   });
 
   test('When the value of one of its form elements changes, its value is updated.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({ name: 'firstName', defaultValue: '' }),
@@ -361,7 +364,7 @@ describe('Form', () => {
   });
 
   test('When the value of one of its adapters changes, its value is updated.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({
@@ -409,7 +412,7 @@ describe('Form', () => {
   });
 
   test('When the validity of one of its form elements changes, its validity is updated.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({
@@ -428,7 +431,7 @@ describe('Form', () => {
   });
 
   test('When the validity of one of its groups changes, its validity is updated.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'password', defaultValue: 'password' }),
@@ -459,7 +462,7 @@ describe('Form', () => {
   });
 
   test('When confirm() is called, confirmationAttempted is set to true.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = [];
     }
@@ -472,7 +475,7 @@ describe('Form', () => {
   });
 
   test("When confirm() is called with an onSuccess callback and the form is valid, that callback is called with the form's value.", () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -516,7 +519,7 @@ describe('Form', () => {
     class Template<
         ControllingField extends AbstractField<string, boolean, boolean>,
       >
-      extends FormTemplate
+      extends SubFormTemplate
       implements ControllableTemplate<ControllingField>
     {
       public readonly name = 'TestForm';
@@ -544,7 +547,7 @@ describe('Form', () => {
   });
 
   test('When confirm() is called with an onFailure callback and the form is invalid, that callback is called.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -570,7 +573,7 @@ describe('Form', () => {
         return promiseScheduler.createScheduledPromise(value.length > 0);
       },
     });
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -590,17 +593,17 @@ describe('Form', () => {
   });
 
   test('When confirm() is called, all of its subforms are confirmed as well.', () => {
-    class InnerFormTemplate extends FormTemplate {
+    class InnerSubFormTemplate extends SubFormTemplate {
       public readonly name = 'subForm';
       public readonly formElements = [];
     }
 
-    const InnerForm = FormFactory.createExcludableSubForm(InnerFormTemplate);
-    class OuterFormTemplate extends FormTemplate {
+    const InnerForm = FormFactory.createExcludableSubForm(InnerSubFormTemplate);
+    class OuterSubFormTemplate extends SubFormTemplate {
       public readonly name = 'outerForm';
       public readonly formElements = <const>[new InnerForm()];
     }
-    const OuterForm = FormFactory.createExcludableSubForm(OuterFormTemplate);
+    const OuterForm = FormFactory.createExcludableSubForm(OuterSubFormTemplate);
     const instance = new OuterForm();
     const spy = vi.spyOn(instance.formElements.subForm, 'confirm');
     instance.confirm();
@@ -608,7 +611,7 @@ describe('Form', () => {
   });
 
   test('When reset() is called, confirmationAttempted is set to false.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = [];
     }
@@ -623,7 +626,7 @@ describe('Form', () => {
   });
 
   test('When reset() is called, reset is called on all of its form elements.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'firstName', defaultValue: '' }),
@@ -667,7 +670,7 @@ describe('Form', () => {
   });
 
   test('When reset() is called, the exclude property of its state becomes excludeByDefault.', () => {
-    class Template extends FormTemplate implements ExcludableTemplate {
+    class Template extends SubFormTemplate implements ExcludableTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = [];
       public readonly excludeByDefault = true;
@@ -687,7 +690,7 @@ describe('Form', () => {
     class Template<
         ControllingField extends AbstractField<string, boolean, boolean>,
       >
-      extends FormTemplate
+      extends SubFormTemplate
       implements ControllableTemplate<ControllingField>
     {
       public readonly name = 'TestForm';
@@ -727,7 +730,7 @@ describe('Form', () => {
         );
       },
     });
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({
@@ -775,7 +778,7 @@ describe('Form', () => {
   });
 
   test('After subscribeToConfirmationAttempted() has been called, updates to confirmationAttempted are emitted to subscribers.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = [];
     }

--- a/src/__test__/model/form-elements/classes/abstract/form.test.ts
+++ b/src/__test__/model/form-elements/classes/abstract/form.test.ts
@@ -12,24 +12,13 @@ import {
   GroupValiditySource,
   AsyncValidator,
   type ExcludableAdaptFnReturnType,
+  SubFormTemplate,
 } from '../../../../../model';
 import { PromiseScheduler } from '../../../../../test-utils';
 
 describe('Form', () => {
-  test('Its id defaults to its name.', () => {
-    class Template extends FormTemplate {
-      public readonly name = 'TestForm';
-      public readonly formElements = [];
-    }
-    const TestForm = FormFactory.createForm(Template);
-    const instance = new TestForm();
-    expect(instance.name).toBe('TestForm');
-    expect(instance.id).toBe(instance.name);
-  });
-
   test('Its value consists of all included, non-transient fields.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'firstName', defaultValue: 'Georg' }),
         new ExcludableField({ name: 'middleName', defaultValue: 'Christoph' }),
@@ -47,7 +36,6 @@ describe('Form', () => {
 
   test('Its value does not include any transient fields.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'password', defaultValue: '' }),
         new Field({
@@ -66,7 +54,6 @@ describe('Form', () => {
 
   test('Its value does not include the values of any excluded excludable fields.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'primaryEmail', defaultValue: 'user@example.com' }),
         new ExcludableField({
@@ -85,7 +72,6 @@ describe('Form', () => {
 
   test('Its value includes the values of any included user-defined adapters.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'birthYear', defaultValue: '1990', transient: true }),
       ];
@@ -108,7 +94,6 @@ describe('Form', () => {
 
   test('Its value does not include the values of any excluded excludable adapters.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'firstName', defaultValue: '' }),
         new ExcludableField({
@@ -145,7 +130,6 @@ describe('Form', () => {
 
   test('If any included fields are invalid, its validity is invalid.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
           name: 'requiredField',
@@ -161,7 +145,6 @@ describe('Form', () => {
 
   test('If any groups are invalid, its validity is invalid.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'password', defaultValue: 'password' }),
         new Field({ name: 'confirmPassword', defaultValue: '' }),
@@ -197,7 +180,6 @@ describe('Form', () => {
       },
     });
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
           name: 'pendingField',
@@ -214,7 +196,6 @@ describe('Form', () => {
   test('If there is at least one pending group and no invalid fields or groups, its validity is pending.', () => {
     const promiseScheduler = new PromiseScheduler();
     class Template extends FormTemplate {
-      public readonly name = 'AddressForm';
       public formElements = <const>[
         new Field({ name: 'streetAddress', defaultValue: '1726 Locust St.' }),
         new Field({ name: 'city', defaultValue: 'Philadelphia' }),
@@ -257,7 +238,6 @@ describe('Form', () => {
 
   test('If all fields and groups are valid, its validity is valid.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
           name: 'password',
@@ -291,7 +271,6 @@ describe('Form', () => {
 
   test('When the value of one of its form elements changes, its value is updated.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({ name: 'firstName', defaultValue: '' }),
         new Field({ name: 'lastName', defaultValue: '' }),
@@ -320,7 +299,6 @@ describe('Form', () => {
 
   test('When the value of one of its adapters changes, its value is updated.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({
           name: 'firstName',
@@ -368,7 +346,6 @@ describe('Form', () => {
 
   test('When the validity of one of its form elements changes, its validity is updated.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({
           name: 'requiredField',
@@ -387,7 +364,6 @@ describe('Form', () => {
 
   test('When the validity of one of its groups changes, its validity is updated.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'password', defaultValue: 'password' }),
         new Field({ name: 'confirmPassword', defaultValue: '' }),
@@ -418,7 +394,6 @@ describe('Form', () => {
 
   test('When confirm() is called, confirmationAttempted is set to true.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public readonly formElements = [];
     }
     const TestForm = FormFactory.createForm(Template);
@@ -431,7 +406,6 @@ describe('Form', () => {
 
   test("When confirm() is called with an onSuccess callback and the form is valid, that callback is called with the form's value.", () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
           name: 'firstName',
@@ -472,7 +446,6 @@ describe('Form', () => {
 
   test('When confirm() is called with an onFailure callback and the form is invalid, that callback is called.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
           name: 'requiredField',
@@ -498,7 +471,6 @@ describe('Form', () => {
       },
     });
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
           name: 'pendingField',
@@ -517,13 +489,12 @@ describe('Form', () => {
   });
 
   test('When confirm() is called, all of its subforms are confirmed as well.', () => {
-    class InnerFormTemplate extends FormTemplate {
+    class InnerFormTemplate extends SubFormTemplate {
       public readonly name = 'subForm';
       public readonly formElements = [];
     }
     const InnerForm = FormFactory.createSubForm(InnerFormTemplate);
     class OuterFormTemplate extends FormTemplate {
-      public readonly name = 'outerForm';
       public readonly formElements = <const>[new InnerForm()];
     }
     const OuterForm = FormFactory.createForm(OuterFormTemplate);
@@ -535,7 +506,6 @@ describe('Form', () => {
 
   test('When reset() is called, confirmationAttempted is set to false.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public readonly formElements = [];
     }
     const TestForm = FormFactory.createForm(Template);
@@ -550,7 +520,6 @@ describe('Form', () => {
 
   test('When reset() is called, reset is called on all of its form elements.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'firstName', defaultValue: '' }),
         new Field({ name: 'middleName', defaultValue: '' }),
@@ -603,7 +572,6 @@ describe('Form', () => {
       },
     });
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({
           name: 'email',
@@ -648,7 +616,6 @@ describe('Form', () => {
 
   test('After subscribeToConfirmationAttempted() has been called, updates to confirmationAttempted are emitted to subscribers.', () => {
     class Template extends FormTemplate {
-      public readonly name = 'TestForm';
       public readonly formElements = [];
     }
     const TestForm = FormFactory.createForm(Template);

--- a/src/__test__/model/form-elements/classes/abstract/subform.test.ts
+++ b/src/__test__/model/form-elements/classes/abstract/subform.test.ts
@@ -13,11 +13,11 @@ import {
   type ExcludableAdaptFnReturnType,
 } from '../../../../../model';
 import { PromiseScheduler } from '../../../../../test-utils';
-import { FormTemplate } from '../../../../../model';
+import { SubFormTemplate } from '../../../../../model';
 
 describe('Form', () => {
   test('Its id defaults to its name.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = [];
     }
@@ -28,7 +28,7 @@ describe('Form', () => {
   });
 
   test('Its value consists of all included, non-transient fields.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'firstName', defaultValue: 'Georg' }),
@@ -46,7 +46,7 @@ describe('Form', () => {
   });
 
   test('Its value does not include any transient fields.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'password', defaultValue: '' }),
@@ -65,7 +65,7 @@ describe('Form', () => {
   });
 
   test('Its value does not include the values of any excluded excludable fields.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'primaryEmail', defaultValue: 'user@example.com' }),
@@ -84,7 +84,7 @@ describe('Form', () => {
   });
 
   test('Its value includes the values of any included user-defined adapters.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'birthYear', defaultValue: '1990', transient: true }),
@@ -107,7 +107,7 @@ describe('Form', () => {
   });
 
   test('Its value does not include the values of any excluded excludable adapters.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'firstName', defaultValue: '' }),
@@ -144,7 +144,7 @@ describe('Form', () => {
   });
 
   test('If any included fields are invalid, its validity is invalid.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -160,7 +160,7 @@ describe('Form', () => {
   });
 
   test('If any groups are invalid, its validity is invalid.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'password', defaultValue: 'password' }),
@@ -196,7 +196,7 @@ describe('Form', () => {
         return promiseScheduler.createScheduledPromise(value.length > 0);
       },
     });
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -213,7 +213,7 @@ describe('Form', () => {
 
   test('If there is at least one pending group and no invalid fields or groups, its validity is pending.', () => {
     const promiseScheduler = new PromiseScheduler();
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'AddressForm';
       public formElements = <const>[
         new Field({ name: 'streetAddress', defaultValue: '1726 Locust St.' }),
@@ -256,7 +256,7 @@ describe('Form', () => {
   });
 
   test('If all fields and groups are valid, its validity is valid.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -290,7 +290,7 @@ describe('Form', () => {
   });
 
   test('When the value of one of its form elements changes, its value is updated.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({ name: 'firstName', defaultValue: '' }),
@@ -319,7 +319,7 @@ describe('Form', () => {
   });
 
   test('When the value of one of its adapters changes, its value is updated.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({
@@ -367,7 +367,7 @@ describe('Form', () => {
   });
 
   test('When the validity of one of its form elements changes, its validity is updated.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({
@@ -386,7 +386,7 @@ describe('Form', () => {
   });
 
   test('When the validity of one of its groups changes, its validity is updated.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'password', defaultValue: 'password' }),
@@ -417,7 +417,7 @@ describe('Form', () => {
   });
 
   test('When confirm() is called, confirmationAttempted is set to true.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = [];
     }
@@ -430,7 +430,7 @@ describe('Form', () => {
   });
 
   test("When confirm() is called with an onSuccess callback and the form is valid, that callback is called with the form's value.", () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -471,7 +471,7 @@ describe('Form', () => {
   });
 
   test('When confirm() is called with an onFailure callback and the form is invalid, that callback is called.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -497,7 +497,7 @@ describe('Form', () => {
         return promiseScheduler.createScheduledPromise(value.length > 0);
       },
     });
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({
@@ -517,17 +517,17 @@ describe('Form', () => {
   });
 
   test('When confirm() is called, all of its subforms are confirmed as well.', () => {
-    class InnerFormTemplate extends FormTemplate {
+    class InnerSubFormTemplate extends SubFormTemplate {
       public readonly name = 'subForm';
       public readonly formElements = [];
     }
 
-    const InnerForm = FormFactory.createSubForm(InnerFormTemplate);
-    class OuterFormTemplate extends FormTemplate {
+    const InnerForm = FormFactory.createSubForm(InnerSubFormTemplate);
+    class OuterSubFormTemplate extends SubFormTemplate {
       public readonly name = 'outerForm';
       public readonly formElements = <const>[new InnerForm()];
     }
-    const OuterForm = FormFactory.createSubForm(OuterFormTemplate);
+    const OuterForm = FormFactory.createSubForm(OuterSubFormTemplate);
     const instance = new OuterForm();
     const spy = vi.spyOn(instance.formElements.subForm, 'confirm');
     instance.confirm();
@@ -535,7 +535,7 @@ describe('Form', () => {
   });
 
   test('When reset() is called, confirmationAttempted is set to false.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = [];
     }
@@ -550,7 +550,7 @@ describe('Form', () => {
   });
 
   test('When reset() is called, reset is called on all of its form elements.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public formElements = <const>[
         new Field({ name: 'firstName', defaultValue: '' }),
@@ -603,7 +603,7 @@ describe('Form', () => {
         );
       },
     });
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = <const>[
         new Field({
@@ -648,7 +648,7 @@ describe('Form', () => {
   });
 
   test('After subscribeToConfirmationAttempted() has been called, updates to confirmationAttempted are emitted to subscribers.', () => {
-    class Template extends FormTemplate {
+    class Template extends SubFormTemplate {
       public readonly name = 'TestForm';
       public readonly formElements = [];
     }

--- a/src/hooks/use-confirmation-attempted.ts
+++ b/src/hooks/use-confirmation-attempted.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import type { AbstractForm, FormConstituents } from '../model';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { AnyForm, AbstractForm } from '../model';
 
 /**
  * Takes in an {@link AbstractForm} and returns a React state variable of type
@@ -15,9 +16,7 @@ import type { AbstractForm, FormConstituents } from '../model';
  * The variable returned by this hook will be updated whenever the
  * `confirmationAttempted` property of the form is updated.
  */
-export function useConfirmationAttempted<
-  T extends AbstractForm<string, FormConstituents>,
->(form: T): boolean {
+export function useConfirmationAttempted<T extends AnyForm>(form: T): boolean {
   const [confirmationAttempted, setConfirmationAttempted] = useState<boolean>(
     form.confirmationAttempted,
   );

--- a/src/hooks/use-form-state.ts
+++ b/src/hooks/use-form-state.ts
@@ -1,5 +1,6 @@
 import { useStatefulEntityState } from './use-stateful-entity-state';
-import type { AbstractForm, FormConstituents } from '../model';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { AnyForm, AbstractForm } from '../model';
 
 /**
  * Takes in an {@link AbstractForm} and returns a React state variable
@@ -14,8 +15,6 @@ import type { AbstractForm, FormConstituents } from '../model';
  * The variable returned by this hook will be updated whenever the `state`
  * property of the form changes.
  */
-export function useFormState<T extends AbstractForm<string, FormConstituents>>(
-  form: T,
-): T['state'] {
+export function useFormState<T extends AnyForm>(form: T): T['state'] {
   return useStatefulEntityState(form);
 }

--- a/src/hooks/use-form.ts
+++ b/src/hooks/use-form.ts
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import type { AbstractForm, FormConstituents } from '../model';
+import type { AnyForm, AbstractForm } from '../model';
 
 /**
  * Persists an instance of {@link AbstractForm} across component re-renders.
@@ -8,8 +8,6 @@ import type { AbstractForm, FormConstituents } from '../model';
  *
  * @returns The persisted {@link AbstractForm} instance.
  */
-export function useForm<T extends AbstractForm<string, FormConstituents>>(
-  form: T,
-): T {
+export function useForm<T extends AnyForm>(form: T): T {
   return useRef(form).current;
 }

--- a/src/model/factories/classes/static/form-factory.ts
+++ b/src/model/factories/classes/static/form-factory.ts
@@ -1,5 +1,9 @@
 import { Form, SubForm, ExcludableSubForm } from '../../../form-elements';
-import type { ControllableTemplate, FormTemplate } from '../../../templates';
+import type {
+  ControllableTemplate,
+  FormTemplate,
+  SubFormTemplate,
+} from '../../../templates';
 import type { Constructor } from '../../../shared';
 import type {
   AbstractExcludableSubForm,
@@ -35,10 +39,8 @@ export class FormFactory {
   public static createForm<
     Args extends unknown[],
     T extends FormTemplate & AllowedConstituents<T>,
-  >(
-    Template: Constructor<Args, T>,
-  ): Constructor<Args, AbstractForm<T['name'], T>> {
-    return class extends Form<T['name'], T> {
+  >(Template: Constructor<Args, T>): Constructor<Args, AbstractForm<T>> {
+    return class extends Form<T> {
       public constructor(...args: Args) {
         super(new Template(...args));
       }
@@ -62,7 +64,7 @@ export class FormFactory {
    */
   public static createSubForm<
     Args extends unknown[],
-    T extends FormTemplate & AllowedConstituents<T>,
+    T extends SubFormTemplate & AllowedConstituents<T>,
   >(
     Template: Constructor<Args, T>,
   ): Constructor<
@@ -101,8 +103,8 @@ export class FormFactory {
     Args extends unknown[],
     Controller extends FormElement | AbstractGroup<string, GroupMembers>,
     T extends
-      | (FormTemplate & AllowedConstituents<T>)
-      | (FormTemplate &
+      | (SubFormTemplate & AllowedConstituents<T>)
+      | (SubFormTemplate &
           AllowedConstituents<T> &
           ControllableTemplate<Controller>),
   >(

--- a/src/model/form-elements/classes/abstract/abstract-form.ts
+++ b/src/model/form-elements/classes/abstract/abstract-form.ts
@@ -1,11 +1,5 @@
 import type { Subscription } from 'rxjs';
-import type {
-  Identifiable,
-  Nameable,
-  NameableObject,
-  Resettable,
-  Stateful,
-} from '../../../shared';
+import type { NameableObject, Resettable, Stateful } from '../../../shared';
 import type {
   ConfirmMethodArgs,
   FormValue,
@@ -20,18 +14,9 @@ import type {
  *
  * @typeParam Contituents - An object extending {@link FormConstituents}.
  */
-export abstract class AbstractForm<
-    Name extends string,
-    Constituents extends FormConstituents,
-  >
-  implements
-    Nameable<Name>,
-    Identifiable,
-    Stateful<FormState<Constituents>>,
-    Resettable
+export abstract class AbstractForm<Constituents extends FormConstituents>
+  implements Stateful<FormState<Constituents>>, Resettable
 {
-  public abstract name: Name;
-  public abstract id: string;
   public abstract formElements: NameableObject<Constituents['formElements']>;
   public abstract groups: NameableObject<Constituents['groups']>;
   public abstract derivedValues: NameableObject<Constituents['derivedValues']>;

--- a/src/model/form-elements/classes/abstract/abstract-subform.ts
+++ b/src/model/form-elements/classes/abstract/abstract-subform.ts
@@ -1,5 +1,5 @@
 import { AbstractForm } from './abstract-form';
-import type { PossiblyTransient } from '../../../shared';
+import type { Nameable, PossiblyTransient } from '../../../shared';
 import type { FormConstituents } from '../../types';
 
 /**
@@ -17,8 +17,10 @@ export abstract class AbstractSubForm<
     Constituents extends FormConstituents,
     Transient extends boolean,
   >
-  extends AbstractForm<Name, Constituents>
-  implements PossiblyTransient<Transient>
+  extends AbstractForm<Constituents>
+  implements Nameable<Name>, PossiblyTransient<Transient>
 {
+  public abstract name: Name;
+  public abstract id: string;
   public abstract transient: Transient;
 }

--- a/src/model/form-elements/classes/abstract/form.ts
+++ b/src/model/form-elements/classes/abstract/form.ts
@@ -28,16 +28,11 @@ import type { AllowedConstituents } from '../../types';
  * completed with constituents and other settings by passing a template to the
  * `createForm()` method of the {@link FormFactory} class.
  *
- * @typeParam Name - A string literal representing the name of the form.
- *
  * @typeParam Contituents - An object extending {@link FormConstituents}.
  */
 export abstract class Form<
-  Name extends string,
   Constituents extends FormConstituents & AllowedConstituents<Constituents>,
-> extends AbstractForm<Name, Constituents> {
-  public readonly name: Name;
-  public readonly id: string;
+> extends AbstractForm<Constituents> {
   public readonly formElements: NameableObject<Constituents['formElements']>;
   public readonly groups: NameableObject<Constituents['groups']>;
   public readonly derivedValues: NameableObject<Constituents['derivedValues']>;
@@ -57,17 +52,13 @@ export abstract class Form<
   }
 
   public constructor({
-    name,
-    id = name,
     formElements,
     adapters,
     groups,
     derivedValues,
     autoTrim = false,
-  }: FormConstructorArgs<Name, Constituents>) {
+  }: FormConstructorArgs<Constituents>) {
     super();
-    this.name = name;
-    this.id = id;
     this.formElements =
       NameableObjectFactory.createNameableObjectFromArray(formElements);
     this.groups = NameableObjectFactory.createNameableObjectFromArray(groups);

--- a/src/model/form-elements/types/any-form.type.ts
+++ b/src/model/form-elements/types/any-form.type.ts
@@ -1,4 +1,4 @@
 import type { AbstractForm } from '../classes';
 import type { FormConstituents } from './form-constituents.type';
 
-export type AnyForm = AbstractForm<string, FormConstituents>;
+export type AnyForm = AbstractForm<FormConstituents>;

--- a/src/model/form-elements/types/form-constructor-args.type.ts
+++ b/src/model/form-elements/types/form-constructor-args.type.ts
@@ -6,19 +6,12 @@ import type { Form } from '../classes';
 /**
  * An object passed as an argument to the constructor of a {@link Form}.
  *
- * @typeParam Name - A string literal representing the name of the form.
- *
  * @typeParam Contituents - An object extending {@link FormConstituents}.
  */
-export type FormConstructorArgs<
-  Name extends string,
-  Constituents extends FormConstituents,
-> = {
-  name: Name;
+export type FormConstructorArgs<Constituents extends FormConstituents> = {
   formElements: Constituents['formElements'];
   groups: Constituents['groups'];
   adapters: Constituents['adapters'];
   derivedValues: Constituents['derivedValues'];
   autoTrim?: AutoTrim;
-  id?: string;
 };

--- a/src/model/form-elements/types/subform-constructor-args.type.ts
+++ b/src/model/form-elements/types/subform-constructor-args.type.ts
@@ -17,6 +17,8 @@ export type SubFormConstructorArgs<
   Name extends string,
   Constituents extends FormConstituents,
   Transient extends boolean,
-> = FormConstructorArgs<Name, Constituents> & {
+> = FormConstructorArgs<Constituents> & {
+  name: Name;
+  id?: string;
   transient?: Transient;
 };

--- a/src/model/templates/classes/abstract/form-template.ts
+++ b/src/model/templates/classes/abstract/form-template.ts
@@ -23,7 +23,6 @@ import type { FormFactory } from '../../../factories';
  * `formElements` properties to be defined by subclasses.
  */
 export abstract class FormTemplate {
-  public abstract name: string;
   public abstract formElements: readonly FormElement[];
   public readonly adapters: ReadonlyArray<
     AbstractAdapter<
@@ -38,5 +37,4 @@ export abstract class FormTemplate {
     AbstractDerivedValue<string, unknown>
   > = [];
   public autoTrim: AutoTrim = false;
-  public id?: string;
 }

--- a/src/model/templates/classes/abstract/index.ts
+++ b/src/model/templates/classes/abstract/index.ts
@@ -1,1 +1,2 @@
 export { FormTemplate } from './form-template';
+export { SubFormTemplate } from './subform-template';

--- a/src/model/templates/classes/abstract/subform-template.ts
+++ b/src/model/templates/classes/abstract/subform-template.ts
@@ -1,0 +1,6 @@
+import { FormTemplate } from './form-template';
+
+export abstract class SubFormTemplate extends FormTemplate {
+  public abstract name: string;
+  public id?: string;
+}


### PR DESCRIPTION
Removed the name property from top-level forms and form templates as it is never used. Subforms and excludable subforms still require a name property.