### PR TITLE
prevent setSubmitted from being called on excluded elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fully-formed",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Powerful, type-safe, style-agnostic forms for React.",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/model/form-elements/classes/abstract-excludable-subform.ts
+++ b/src/model/form-elements/classes/abstract-excludable-subform.ts
@@ -1,6 +1,7 @@
 import { Subject, type Subscription } from 'rxjs';
 import {
   createRecordFromNameableArray,
+  isExcludable,
   isResettable,
   isSubmittable,
 } from '../../utils';
@@ -145,7 +146,10 @@ export abstract class AbstractExcludableSubForm<
 
   public setSubmitted(): void {
     for (const field of Object.values(this.fields)) {
-      if (isSubmittable(field)) {
+      if (
+        isSubmittable(field) &&
+        (!isExcludable(field) || !field.state.exclude)
+      ) {
         field.setSubmitted();
       }
     }

--- a/src/model/form-elements/classes/abstract-form.ts
+++ b/src/model/form-elements/classes/abstract-form.ts
@@ -4,6 +4,7 @@ import {
   createRecordFromNameableArray,
   isResettable,
   isSubmittable,
+  isExcludable,
 } from '../../utils';
 import { FormReducerFactory } from '../../factories';
 import type { StateWithChanges, RecordFromNameableArray } from '../../shared';
@@ -78,7 +79,10 @@ export abstract class AbstractForm<T extends FormMembers> implements IForm<T> {
 
   public setSubmitted(): void {
     for (const field of Object.values(this.fields)) {
-      if (isSubmittable(field)) {
+      if (
+        isSubmittable(field) &&
+        (!isExcludable(field) || !field.state.exclude)
+      ) {
         field.setSubmitted();
       }
     }


### PR DESCRIPTION
This PR prevents setSubmitted from being called on exclude sub form elements. This improves users experience by keeping these fields pristine until such time that they are included and submitted.